### PR TITLE
fix case declaration eslint violation

### DIFF
--- a/src/apply_resource_manager.js
+++ b/src/apply_resource_manager.js
@@ -181,8 +181,7 @@ function createResourceReducer(resourceConfig) {
         });
         return { ...state, ...cacheToUpdate };
 
-      // FIXME: figure out why eslint is messed up here
-      case RESOURCE_RECEIVED: // eslint-disable-line
+      case RESOURCE_RECEIVED: {
         if (!buildBatches) {
           cacheToUpdate[createCacheKey(action.request.params)] = {
             result: parseResponse(action.response),
@@ -217,7 +216,7 @@ function createResourceReducer(resourceConfig) {
         });
 
         return { ...state, ...cacheToUpdate };
-
+      }
       case RESOURCE_ERROR:
         paramsList = buildBatches ? action.request : [action.request];
         paramsList.forEach(({ params, retry }) => {


### PR DESCRIPTION
so you cant declare `let`, `const`, etc inside of switch case statements without a block scope. Kinda extreme but I see how you could accidentally pollute your hoisting logic or something
