### PR TITLE
fixme: adding debounce util + removing underscore as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "react": "^15.2.1",
-    "redux": "^3.5.2",
-    "underscore": "^1.8.3"
+    "redux": "^3.5.2"
   }
 }

--- a/src/apply_resource_manager.js
+++ b/src/apply_resource_manager.js
@@ -1,6 +1,5 @@
 import { combineReducers } from 'redux';
-import { debounce } from 'underscore'; // TODO: implement this in utils
-
+import debounce from './utils/debounce';
 import fetchJSON from './utils/fetch_json';
 import mapObject from './utils/map_object';
 import identity from './utils/identity';

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -2,6 +2,10 @@ const now = Date.now || function _now() {
   return new Date().getTime();
 };
 
+/*
+ * Adapted from underscore.js 1.8.3
+ * "immediate" logic here is for covering edge cases
+ */
 export default function debounce(fn, wait, immediate) {
   let timeout;
   let args;

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,40 @@
+const now = Date.now || function _now() {
+  return new Date().getTime();
+};
+
+export default function debounce(fn, wait, immediate) {
+  let timeout;
+  let args;
+  let context;
+  let timestamp;
+  let result;
+
+  const later = () => {
+    const last = now() - timestamp;
+
+    if (last < wait && last >= 0) {
+      timeout = setTimeout(later, wait - last);
+    } else {
+      timeout = null;
+      if (!immediate) {
+        result = fn.apply(context, args);
+        if (!timeout) context = args = null;
+      }
+    }
+  };
+
+  return function debouncedFn(...debounceArgs) {
+    context = this;
+    args = debounceArgs;
+    timestamp = now();
+    const callNow = immediate && !timeout;
+
+    if (!timeout) timeout = setTimeout(later, wait);
+    if (callNow) {
+      result = fn.apply(context, args);
+      context = args = null;
+    }
+
+    return result;
+  };
+}


### PR DESCRIPTION
tackling some TODO's while reading the source code. This seemed like a good one. No need to require all of underscore for one func and makes it more flexible for people who dont want underscore (lodash stans for example)

New debounce util is just underscore's version in ES6 + conforming to eslint rules.
