### PR TITLE
changing default error message to be actual error object

### DIFF
--- a/src/apply_resource_manager.js
+++ b/src/apply_resource_manager.js
@@ -223,7 +223,7 @@ function createResourceReducer(resourceConfig) {
             status: 'rejected',
             retry: retry,
             expiration: Date.now() + ttl,
-            error: 'Fetch error', // bad default message????
+            error: action.error,
           };
         });
         return { ...state, ...cacheToUpdate };


### PR DESCRIPTION
in order to capture error events we should dispatch the actual `Error` object and not just a string message
