### PR TITLE
export actions

### DIFF
--- a/src/apply_resource_manager.js
+++ b/src/apply_resource_manager.js
@@ -5,9 +5,9 @@ import mapObject from './utils/map_object';
 import identity from './utils/identity';
 
 
-const RESOURCE_FETCH = 'RESOURCE_FETCH';
-const RESOURCE_RECEIVED = 'RESOURCE_RECEIVED';
-const RESOURCE_ERROR = 'RESOURCE_ERROR';
+export const RESOURCE_FETCH = 'RESOURCE_FETCH';
+export const RESOURCE_RECEIVED = 'RESOURCE_RECEIVED';
+export const RESOURCE_ERROR = 'RESOURCE_ERROR';
 
 const userState = '__userState';
 const resourceManagerState = '__resourceManagerState';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
-import applyResourceManager from './apply_resource_manager';
+import applyResourceManager,
+    { RESOURCE_FETCH, RESOURCE_RECEIVED, RESOURCE_ERROR } from './apply_resource_manager';
 import connectResourceManager from './connect_resource_manager';
 
 module.exports = {
   applyResourceManager: applyResourceManager,
   connectResourceManager: connectResourceManager,
+  RESOURCE_FETCH,
+  RESOURCE_RECEIVED,
+  RESOURCE_ERROR,
 };


### PR DESCRIPTION
Export the resource manager's actions so that they can be used by other middleware (e.g. an event  logger.)
